### PR TITLE
Update landing page privacy text and footer year

### DIFF
--- a/frontend/landing.html
+++ b/frontend/landing.html
@@ -92,7 +92,7 @@
                         </div>
                         <div class="description-item">
                             <h3>Privacy First</h3>
-                            <p>All processing happens locally in your browser. Your video feed is never stored or sent to external servers, ensuring complete privacy.</p>
+                            <p>All processing runs entirely in your browser using on-device AI. Your webcam feed never leaves your machine.</p>
                         </div>
                         <div class="description-item">
                             <h3>Research Backed</h3>
@@ -107,7 +107,7 @@
     <footer>
         <div class="footer-content">
             <div class="footer-logo">SitRight</div>
-            <p>© 2025 SitRight • AI-Powered Posture Detection</p>
+            <p>© 2026 SitRight • AI-Powered Posture Detection</p>
         </div>
     </footer>
 </body>


### PR DESCRIPTION
## Summary
- Updated "Privacy First" description to reflect on-device AI inference messaging
- Updated footer copyright year from 2025 to 2026

## Test plan
- [ ] Verify landing page renders correctly with updated text
- [ ] Confirm no other content was changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)